### PR TITLE
calculate detection size as a point in metres

### DIFF
--- a/src/orion_recognition/bbox_publisher.py
+++ b/src/orion_recognition/bbox_publisher.py
@@ -9,6 +9,7 @@ import numpy as np
 import os
 import rospy
 import std_msgs.msg
+from geometry_msgs.msg import Point
 from sensor_msgs.msg import CameraInfo, Image
 from cv_bridge import CvBridge, CvBridgeError
 from colornames import ColorNames


### PR DESCRIPTION
Find the location of top left and bottom right point in the object in the camera frame in metres.

Then object size is based on vector from top left to bottom right. 

Not tested.